### PR TITLE
[Form Label] Add missing function to set title by string

### DIFF
--- a/library/src/main/java/com/oursky/widget/SFormLabel.kt
+++ b/library/src/main/java/com/oursky/widget/SFormLabel.kt
@@ -213,6 +213,9 @@ open class SFormLabel : LinearLayout {
     fun setTitle(resid: Int) {
         wTitle.setText(resid)
     }
+    fun setTitle(text: String?) {
+        wTitle.setText(text, TextView.BufferType.EDITABLE)
+    }
     fun setHint(resid: Int) {
         wValue.setHint(resid)
     }


### PR DESCRIPTION
This PR added the missing function to set title of a form label by a string value.